### PR TITLE
Update `wat` dependency to version 1.217.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2631,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.216.0"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c23aebea22c8a75833ae08ed31ccc020835b12a41999e58c31464271b94a88"
+checksum = "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
 dependencies = [
  "leb128",
 ]
@@ -2747,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "216.0.0"
+version = "217.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7eb1f2eecd913fdde0dc6c3439d0f24530a98ac6db6cb3d14d92a5328554a08"
+checksum = "79004ecebded92d3c710d4841383368c7f04b63d0992ddd6b0c7d5029b7629b7"
 dependencies = [
  "bumpalo",
  "leb128",
@@ -2760,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.216.0"
+version = "1.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0409090fb5154f95fb5ba3235675fd9e579e731524d63b6a2f653e1280c82a"
+checksum = "c126271c3d92ca0f7c63e4e462e40c69cca52fd4245fcda730d1cf558fb55088"
 dependencies = [
  "wast",
 ]

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -32,7 +32,7 @@ derivative = { version = "^2" }
 bytes = "1"
 tracing = { version = "0.1" }
 # - Optional shared dependencies.
-wat = { version = "=1.216.0", optional = true }
+wat = { version = "=1.217.0", optional = true }
 rustc-demangle = "0.1"
 shared-buffer = { workspace = true }
 


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/CONTRIBUTING.md#pull-requests

-->

# Motivation
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
Wasmtime 0.25.0 includes a fix that we need, but using that version of Wasmtime requires `wat` version 1.217.0, which is different than the version that was previously pinned.

# Solution

Update the pinned version in the repository.
