### PR TITLE
Update version to `4.3.6-linera.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer"
-version = "4.3.6-linera.3"
+version = "4.3.6-linera.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-compiler"
-version = "4.3.6-linera.3"
+version = "4.3.6-linera.4"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-compiler-cranelift"
-version = "4.3.6-linera.3"
+version = "4.3.6-linera.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-compiler-singlepass"
-version = "4.3.6-linera.3"
+version = "4.3.6-linera.4"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-vm"
-version = "4.3.6-linera.3"
+version = "4.3.6-linera.4"
 dependencies = [
  "backtrace",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmer = { package = "linera-wasmer", version = "=4.3.6-linera.3", path = "lib/api", default-features = false }
-wasmer-compiler = { package = "linera-wasmer-compiler", version = "=4.3.6-linera.3", path = "lib/compiler", features = [
+wasmer = { package = "linera-wasmer", version = "=4.3.6-linera.4", path = "lib/api", default-features = false }
+wasmer-compiler = { package = "linera-wasmer-compiler", version = "=4.3.6-linera.4", path = "lib/compiler", features = [
     "compiler",
 ], optional = true }
-wasmer-compiler-cranelift = { package = "linera-wasmer-compiler-cranelift", version = "=4.3.6-linera.3", path = "lib/compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", version = "=4.3.6-linera.3", path = "lib/compiler-singlepass", optional = true }
+wasmer-compiler-cranelift = { package = "linera-wasmer-compiler-cranelift", version = "=4.3.6-linera.4", path = "lib/compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", version = "=4.3.6-linera.4", path = "lib/compiler-singlepass", optional = true }
 # wasmer-compiler-llvm = { version = "=4.3.6", path = "lib/compiler-llvm", optional = true }
 # wasmer-emscripten = { version = "=4.3.6", path = "lib/emscripten", optional = true }
 # wasmer-wasix = { path = "lib/wasix", optional = true }
@@ -119,7 +119,7 @@ glob = "0.3"
 rustc_version = "0.4"
 
 [dev-dependencies]
-wasmer = { package = "linera-wasmer", version = "=4.3.6-linera.3", path = "lib/api", features = [
+wasmer = { package = "linera-wasmer", version = "=4.3.6-linera.4", path = "lib/api", features = [
     "compiler",
     "singlepass",
     "sys",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "4.3.6-linera.3"
+version = "4.3.6-linera.4"
 
 #####
 # This crate comes in 2 major flavors:
@@ -39,14 +39,14 @@ shared-buffer = { workspace = true }
 # Dependencies and Development Dependencies for `sys`.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # - Mandatory dependencies for `sys`.
-wasmer-vm = { package = "linera-wasmer-vm", path = "../vm", version = "=4.3.6-linera.3" }
-wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.3.6-linera.3" }
+wasmer-vm = { package = "linera-wasmer-vm", path = "../vm", version = "=4.3.6-linera.4" }
+wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.3.6-linera.4" }
 wasmer-derive = { path = "../derive", version = "=4.3.6" }
 wasmer-types = { path = "../types", version = "=4.3.6" }
 target-lexicon = { version = "0.12.2", default-features = false }
 # - Optional dependencies for `sys`.
-wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", path = "../compiler-singlepass", version = "=4.3.6-linera.3", optional = true }
-wasmer-compiler-cranelift = { package = "linera-wasmer-compiler-cranelift", path = "../compiler-cranelift", version = "=4.3.6-linera.3", optional = true }
+wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", path = "../compiler-singlepass", version = "=4.3.6-linera.4", optional = true }
+wasmer-compiler-cranelift = { package = "linera-wasmer-compiler-cranelift", path = "../compiler-cranelift", version = "=4.3.6-linera.4", optional = true }
 #wasmer-compiler-llvm = { path = "../compiler-llvm", version = "=4.3.6", optional = true }
 
 wasm-bindgen = { version = "0.2.74", optional = true }

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -11,10 +11,10 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "4.3.6-linera.3"
+version = "4.3.6-linera.4"
 
 [dependencies]
-wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.3.6-linera.3", features = ["translator", "compiler"], default-features = false }
+wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.3.6-linera.4", features = ["translator", "compiler"], default-features = false }
 wasmer-types = { path = "../types", version = "=4.3.6", default-features = false, features = ["std"] }
 cranelift-entity = { version = "0.91.1", default-features = false }
 cranelift-codegen = { version = "0.91.1", default-features = false, features = ["x86", "arm64", "riscv64"] }

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -11,10 +11,10 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "4.3.6-linera.3"
+version = "4.3.6-linera.4"
 
 [dependencies]
-wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.3.6-linera.3", features = ["translator", "compiler"], default-features = false }
+wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.3.6-linera.4", features = ["translator", "compiler"], default-features = false }
 wasmer-types = { path = "../types", version = "=4.3.6", default-features = false, features = ["std"] }
 hashbrown = { version = "0.11", optional = true }
 gimli = { version = "0.26", optional = true }

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "4.3.6-linera.3"
+version = "4.3.6-linera.4"
 
 [dependencies]
 wasmer-types = { path = "../types", version = "=4.3.6", default-features = false }
@@ -40,7 +40,7 @@ shared-buffer = { workspace = true }
 libc.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-wasmer-vm = { package = "linera-wasmer-vm", path = "../vm", version = "=4.3.6-linera.3" }
+wasmer-vm = { package = "linera-wasmer-vm", path = "../vm", version = "=4.3.6-linera.4" }
 region = { version = "3.0" }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "4.3.6-linera.3"
+version = "4.3.6-linera.4"
 
 [dependencies]
 memoffset.workspace = true


### PR DESCRIPTION
# Motivation

PR #2 updates the `wat` dependency version, and this is needed to upgrade `wasmtime` to version `25.0.0`. Therefore, a new version of `linera-wasmer` needs to be released.

# Proposal

Increment the fork version to `4.3.6-linera.4`.