### PR TITLE
Convert JavaScript `Module`s from a `JsValue`

### DIFF
--- a/lib/api/src/js/trap.rs
+++ b/lib/api/src/js/trap.rs
@@ -153,7 +153,11 @@ impl From<JsValue> for JsTrap {
     fn from(value: JsValue) -> Self {
         // Let's try some easy special cases first
         if let Some(error) = value.dyn_ref::<js_sys::Error>() {
-            return JsTrap::Message(error.message().into());
+            let backtrace = js_sys::Reflect::get(error, &"stack".into())
+                .unwrap()
+                .as_string()
+                .unwrap();
+            return JsTrap::Message(format!("{}: {}", error.message(), backtrace));
         }
 
         if let Some(s) = value.as_string() {

--- a/lib/api/src/module.rs
+++ b/lib/api/src/module.rs
@@ -483,3 +483,11 @@ impl From<Module> for wasm_bindgen::JsValue {
         wasm_bindgen::JsValue::from(value.0)
     }
 }
+
+#[cfg(feature = "js")]
+impl TryFrom<wasm_bindgen::JsValue> for Module {
+    type Error = <module_imp::Module as TryFrom<wasm_bindgen::JsValue>>::Error;
+    fn try_from(value: wasm_bindgen::JsValue) -> Result<Self, Self::Error> {
+        value.try_into().map(Module)
+    }
+}


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/CONTRIBUTING.md#pull-requests

-->

# Description
Add a `TryFrom` implementation that attempts to create a `wasmer::Module` from a `JsValue` when compiling with the JavaScript backend.

The implementation separates out the metadata such as type hints and serializes it using `serde-wasm-bindgen`, while the module itself is simply cast to a `JsValue`.
 
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
