### PR TITLE
Always build `cdylib` of `linera-wasmer` crate

### DIFF
--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -21,6 +21,9 @@ version = "4.4.0-linera.6"
 #   JavaScript host.
 #####
 
+[lib]
+crate-type = ["cdylib", "lib"]
+
 # Shared dependencies.
 [dependencies]
 # - Mandatory shared dependencies.

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -20,7 +20,6 @@
     clippy::use_self
 )]
 #![allow(deprecated_cfg_attr_crate_type_name)]
-#![cfg_attr(feature = "js", crate_type = "cdylib")]
 
 //! [`Wasmer`](https://wasmer.io/) is the most popular
 //! [WebAssembly](https://webassembly.org/) runtime for Rust. It supports


### PR DESCRIPTION
# Description

Previously, enabling the `web` feature caused `wasmer` to be built as a `cdylib` target. However, this conditional selection of crate type is no longer supported, so the manifest was changed to always produce a `cdylib` binary.