### PR TITLE
Prepare to release `v4.4.0-linera.7`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,28 +315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compiletest_rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0086d6ad78cf409c3061618cd98e2789d5c9ce598fc9651611cf62eae0a599cb"
-dependencies = [
- "diff",
- "filetime",
- "getopts",
- "lazy_static",
- "libc",
- "log",
- "miow",
- "regex",
- "rustfix",
- "serde",
- "serde_derive",
- "serde_json",
- "tester",
- "winapi",
-]
-
-[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,27 +613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,18 +714,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
-name = "filetime"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.4.1",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,15 +761,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1010,16 +946,6 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.6.0",
- "libc",
-]
 
 [[package]]
 name = "linera-wasmer"
@@ -1211,6 +1137,8 @@ dependencies = [
 [[package]]
 name = "macro-wasmer-universal-test"
 version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7d134124a3ddc94d11f70a7811dcfdc9f2dbdca40704dfa4197ef1392e8629"
 dependencies = [
  "proc-macro2",
  "proc-quote",
@@ -1270,15 +1198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,16 +1210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1354,7 +1263,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
  "smallvec",
  "windows-targets",
 ]
@@ -1507,31 +1416,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
 ]
 
 [[package]]
@@ -1669,18 +1558,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustfix"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c50b74badcddeb8f7652fa8323ce440b95286f8e4b64ebfd871c609672704e"
-dependencies = [
- "anyhow",
- "log",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2011,17 +1888,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,19 +1923,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
-]
-
-[[package]]
-name = "tester"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e8bf7e0eb2dd7b4228cc1b6821fc5114cd6841ae59f652a85488c016091e5f"
-dependencies = [
- "cfg-if",
- "getopts",
- "libc",
- "num_cpus",
- "term",
 ]
 
 [[package]]
@@ -2447,18 +2300,20 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5875633aea92153b6a561cb07363785ca9e07792ca6cd7c1cc371761001d8f"
 dependencies = [
- "compiletest_rs",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "wasmer-types",
 ]
 
 [[package]]
 name = "wasmer-object"
 version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff9bd75c81a20b751cecc9d5e056c7d7212950d423664155fd517cdd5d926f"
 dependencies = [
  "object 0.29.0",
  "thiserror",
@@ -2468,6 +2323,8 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb32f0d231b591e4c8a65e81d4647fa3180496d71a123d4948dba8551bba9c2"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -2476,7 +2333,6 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "loupe",
- "memoffset",
  "more-asserts",
  "rkyv",
  "serde",
@@ -2516,6 +2372,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "wasmer-types",
 ]
 
 [[package]]
@@ -2571,22 +2428,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,12 +2435,6 @@ checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-workspace"
-version = "4.4.0"
+version = "4.4.0-linera.6"
 dependencies = [
  "anyhow",
  "build-deps",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "linera-wasmer"
-version = "4.4.0-linera.6"
+version = "4.4.0-linera.7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-compiler"
-version = "4.4.0-linera.6"
+version = "4.4.0-linera.7"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-compiler-cranelift"
-version = "4.4.0-linera.6"
+version = "4.4.0-linera.7"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-compiler-singlepass"
-version = "4.4.0-linera.6"
+version = "4.4.0-linera.7"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-vm"
-version = "4.4.0-linera.6"
+version = "4.4.0-linera.7"
 dependencies = [
  "backtrace",
  "cc",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-workspace"
-version = "4.4.0-linera.6"
+version = "4.4.0-linera.7"
 dependencies = [
  "anyhow",
  "build-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ homepage = "https://wasmer.io/"
 license = "MIT"
 repository = "https://github.com/wasmerio/wasmer"
 rust-version = "1.74"
-version = "4.4.0"
+version = "4.4.0-linera.6"
 
 [workspace.dependencies]
 # Repo-local crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,11 @@ version = "4.4.0-linera.6"
 
 [workspace.dependencies]
 # Repo-local crates
+wasmer-compiler = { package = "linera-wasmer-compiler", path = "./lib/compiler", version = "=4.4.0-linera.6" }
+wasmer-compiler-cranelift = { package = "linera-wasmer-compiler-cranelift", path = "./lib/compiler-cranelift", version = "=4.4.0-linera.6" }
+wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", path = "./lib/compiler-singlepass", version = "=4.4.0-linera.6" }
 wasmer-config = { path = "./lib/config" }
+wasmer-vm = { package = "linera-wasmer-vm", path = "./lib/vm", version = "=4.4.0-linera.6" }
 wasmer-wasix = { path = "./lib/wasix" }
 
 # Wasmer-owned crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,10 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmer = { package = "linera-wasmer", version = "=4.4.0-linera.6", path = "lib/api", default-features = false }
-wasmer-compiler = { package = "linera-wasmer-compiler", version = "=4.4.0-linera.6", path = "lib/compiler", features = [
-    "compiler",
-], optional = true }
-wasmer-compiler-cranelift = { package = "linera-wasmer-compiler-cranelift", version = "=4.4.0-linera.6", path = "lib/compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", version = "=4.4.0-linera.6", path = "lib/compiler-singlepass", optional = true }
+wasmer = { workspace = true, default-features = false }
+wasmer-compiler = { workspace = true, features = ["compiler"], optional = true }
+wasmer-compiler-cranelift = { workspace = true, optional = true }
+wasmer-compiler-singlepass = { workspace = true, optional = true }
 # wasmer-compiler-llvm = { version = "=4.4.0", path = "lib/compiler-llvm", optional = true }
 # wasmer-emscripten = { version = "=4.4.0", path = "lib/emscripten", optional = true }
 # wasmer-wasix = { path = "lib/wasix", optional = true }
@@ -92,6 +90,7 @@ version = "4.4.0-linera.6"
 
 [workspace.dependencies]
 # Repo-local crates
+wasmer = { package = "linera-wasmer", version = "=4.4.0-linera.6", path = "./lib/api" }
 wasmer-compiler = { package = "linera-wasmer-compiler", path = "./lib/compiler", version = "=4.4.0-linera.6" }
 wasmer-compiler-cranelift = { package = "linera-wasmer-compiler-cranelift", path = "./lib/compiler-cranelift", version = "=4.4.0-linera.6" }
 wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", path = "./lib/compiler-singlepass", version = "=4.4.0-linera.6" }
@@ -136,7 +135,7 @@ glob = "0.3"
 rustc_version = "0.4"
 
 [dev-dependencies]
-wasmer = { package = "linera-wasmer", version = "=4.4.0-linera.6", path = "lib/api", features = [
+wasmer = { workspace = true, features = [
     "compiler",
     "singlepass",
     "sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,16 +86,16 @@ homepage = "https://wasmer.io/"
 license = "MIT"
 repository = "https://github.com/wasmerio/wasmer"
 rust-version = "1.74"
-version = "4.4.0-linera.6"
+version = "4.4.0-linera.7"
 
 [workspace.dependencies]
 # Repo-local crates
-wasmer = { package = "linera-wasmer", version = "=4.4.0-linera.6", path = "./lib/api" }
-wasmer-compiler = { package = "linera-wasmer-compiler", path = "./lib/compiler", version = "=4.4.0-linera.6" }
-wasmer-compiler-cranelift = { package = "linera-wasmer-compiler-cranelift", path = "./lib/compiler-cranelift", version = "=4.4.0-linera.6" }
-wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", path = "./lib/compiler-singlepass", version = "=4.4.0-linera.6" }
+wasmer = { package = "linera-wasmer", version = "=4.4.0-linera.7", path = "./lib/api" }
+wasmer-compiler = { package = "linera-wasmer-compiler", path = "./lib/compiler", version = "=4.4.0-linera.7" }
+wasmer-compiler-cranelift = { package = "linera-wasmer-compiler-cranelift", path = "./lib/compiler-cranelift", version = "=4.4.0-linera.7" }
+wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", path = "./lib/compiler-singlepass", version = "=4.4.0-linera.7" }
 wasmer-config = { path = "./lib/config" }
-wasmer-vm = { package = "linera-wasmer-vm", path = "./lib/vm", version = "=4.4.0-linera.6" }
+wasmer-vm = { package = "linera-wasmer-vm", path = "./lib/vm", version = "=4.4.0-linera.7" }
 wasmer-wasix = { path = "./lib/wasix" }
 
 # Wasmer-owned crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", ve
 # wasmer-wast = { version = "=4.4.0", path = "tests/lib/wast", optional = true }
 # wasi-test-generator = { version = "=4.4.0", path = "tests/wasi-wast", optional = true }
 # wasmer-cache = { version = "=4.4.0", path = "lib/cache", optional = true }
-# wasmer-types = { version = "=4.4.0", path = "lib/types" }
+wasmer-types.workspace = true
 # wasmer-middlewares = { version = "=4.4.0", path = "lib/middlewares", optional = true }
 
 # Third party dependencies
@@ -96,6 +96,10 @@ wasmer-config = { path = "./lib/config" }
 wasmer-wasix = { path = "./lib/wasix" }
 
 # Wasmer-owned crates
+macro-wasmer-universal-test = "=4.4.0"
+wasmer-derive = "=4.4.0"
+wasmer-object = "=4.4.0"
+wasmer-types = "=4.4.0"
 webc = { version = "6.1.0", default-features = false, features = ["package"] }
 shared-buffer = "0.1.4"
 

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -46,14 +46,14 @@ loupe = { version = "0.1.3", optional = true, features = [
 # Dependencies and Development Dependencies for `sys`.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # - Mandatory dependencies for `sys`.
-wasmer-vm = { package = "linera-wasmer-vm", path = "../vm", version = "=4.4.0-linera.6" }
-wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.4.0-linera.6" }
+wasmer-vm.workspace = true
+wasmer-compiler.workspace = true
 wasmer-derive.workspace = true
 wasmer-types.workspace = true
 target-lexicon = { version = "0.12.2", default-features = false }
 # - Optional dependencies for `sys`.
-wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", path = "../compiler-singlepass", version = "=4.4.0-linera.6", optional = true }
-wasmer-compiler-cranelift = { package = "linera-wasmer-compiler-cranelift", path = "../compiler-cranelift", version = "=4.4.0-linera.6", optional = true }
+wasmer-compiler-singlepass = { workspace = true, optional = true }
+wasmer-compiler-cranelift = { workspace = true, optional = true }
 #wasmer-compiler-llvm = { path = "../compiler-llvm", version = "=4.4.0", optional = true }
 
 wasm-bindgen = { version = "0.2.74", optional = true }

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -48,8 +48,8 @@ loupe = { version = "0.1.3", optional = true, features = [
 # - Mandatory dependencies for `sys`.
 wasmer-vm = { package = "linera-wasmer-vm", path = "../vm", version = "=4.4.0-linera.6" }
 wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.4.0-linera.6" }
-wasmer-derive = { path = "../derive", version = "=4.4.0" }
-wasmer-types = { path = "../types", version = "=4.4.0" }
+wasmer-derive.workspace = true
+wasmer-types.workspace = true
 target-lexicon = { version = "0.12.2", default-features = false }
 # - Optional dependencies for `sys`.
 wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", path = "../compiler-singlepass", version = "=4.4.0-linera.6", optional = true }
@@ -69,17 +69,15 @@ windows-sys = "0.59"
 wat = "1.0"
 tempfile = "3.6.0"
 anyhow = "1.0"
-macro-wasmer-universal-test = { version = "4.4.0", path = "./macro-wasmer-universal-test" }
+macro-wasmer-universal-test.workspace = true
 
 # Dependencies and Develoment Dependencies for `js`.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # - Mandatory dependencies for `js`.
-wasmer-types = { path = "../types", version = "=4.4.0", default-features = false, features = [
-	"std",
-] }
+wasmer-types = { workspace = true, default-features = false, features = ["std"] }
 wasm-bindgen = "0.2.74"
 js-sys = "0.3.51"
-wasmer-derive = { path = "../derive", version = "=4.4.0" }
+wasmer-derive.workspace = true
 # - Optional dependencies for `js`.
 wasmparser = { workspace = true, default-features = false, optional = true }
 hashbrown = { version = "0.11", optional = true }
@@ -91,7 +89,7 @@ serde = { version = "1.0", features = ["derive"] }
 wat = "1.0"
 anyhow = "1.0"
 wasm-bindgen-test = "0.3.0"
-macro-wasmer-universal-test = { version = "4.4.0", path = "./macro-wasmer-universal-test" }
+macro-wasmer-universal-test.workspace = true
 
 # Specific to `js`.
 #

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "4.4.0-linera.6"
+version.workspace = true
 
 #####
 # This crate comes in 2 major flavors:

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.4.0-linera.6", features = ["translator", "compiler"], default-features = false }
+wasmer-compiler = { workspace = true, features = ["translator", "compiler"], default-features = false }
 wasmer-types = { workspace = true, default-features = false, features = ["std"] }
 cranelift-entity = { version = "0.91.1", default-features = false }
 cranelift-codegen = { version = "0.91.1", default-features = false, features = ["x86", "arm64", "riscv64"] }

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -15,7 +15,7 @@ version = "4.4.0-linera.6"
 
 [dependencies]
 wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.4.0-linera.6", features = ["translator", "compiler"], default-features = false }
-wasmer-types = { path = "../types", version = "=4.4.0", default-features = false, features = ["std"] }
+wasmer-types = { workspace = true, default-features = false, features = ["std"] }
 cranelift-entity = { version = "0.91.1", default-features = false }
 cranelift-codegen = { version = "0.91.1", default-features = false, features = ["x86", "arm64", "riscv64"] }
 cranelift-frontend = { version = "0.91.1", default-features = false }

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "4.4.0-linera.6"
+version.workspace = true
 
 [dependencies]
 wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.4.0-linera.6", features = ["translator", "compiler"], default-features = false }

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.4.0-linera.6", features = ["translator", "compiler"], default-features = false }
+wasmer-compiler = { workspace = true, features = ["translator", "compiler"], default-features = false }
 wasmer-types = { workspace = true, default-features = false, features = ["std"] }
 hashbrown = { version = "0.11", optional = true }
 gimli = { version = "0.26", optional = true }

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -15,7 +15,7 @@ version = "4.4.0-linera.6"
 
 [dependencies]
 wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.4.0-linera.6", features = ["translator", "compiler"], default-features = false }
-wasmer-types = { path = "../types", version = "=4.4.0", default-features = false, features = ["std"] }
+wasmer-types = { workspace = true, default-features = false, features = ["std"] }
 hashbrown = { version = "0.11", optional = true }
 gimli = { version = "0.26", optional = true }
 enumset.workspace = true

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "4.4.0-linera.6"
+version.workspace = true
 
 [dependencies]
 wasmer-compiler = { package = "linera-wasmer-compiler", path = "../compiler", version = "=4.4.0-linera.6", features = ["translator", "compiler"], default-features = false }

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -13,8 +13,8 @@ rust-version.workspace = true
 version = "4.4.0-linera.6"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "=4.4.0", default-features = false }
-wasmer-object = { path = "../object", version = "=4.4.0", optional = true }
+wasmer-types = { workspace = true, default-features = false }
+wasmer-object = { workspace = true, optional = true }
 wasmparser = { workspace = true, optional = true, default-features = false }
 enumset.workspace = true
 hashbrown = { version = "0.11", optional = true }

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "4.4.0-linera.6"
+version.workspace = true
 
 [dependencies]
 wasmer-types = { workspace = true, default-features = false }

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -45,7 +45,7 @@ shared-buffer = { workspace = true }
 libc.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-wasmer-vm = { package = "linera-wasmer-vm", path = "../vm", version = "=4.4.0-linera.6" }
+wasmer-vm.workspace = true
 region = { version = "3.0" }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "4.4.0-linera.6"
+version.workspace = true
 
 [dependencies]
 memoffset.workspace = true

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -15,7 +15,7 @@ version = "4.4.0-linera.6"
 [dependencies]
 memoffset.workspace = true
 dashmap.workspace = true
-wasmer-types = { path = "../types", version = "=4.4.0" }
+wasmer-types.workspace = true
 libc.workspace = true
 indexmap = { version = "1.6" }
 thiserror = "1.0"


### PR DESCRIPTION
# Description

A new version must be released for Linera to support newer Rust versions (https://github.com/linera-io/linera-protocol/issues/3196). The version string was spread among a few different places, which made updating it a little harder than expected, so I tried to join them where possible to simplify the process.
