### PR TITLE
Skip backtrace capture in trap handlers to eliminate lock contention

### DIFF
--- a/lib/compiler/src/engine/trap/stack.rs
+++ b/lib/compiler/src/engine/trap/stack.rs
@@ -7,8 +7,8 @@ use wasmer_vm::Trap;
 pub fn get_trace_and_trapcode(trap: &Trap) -> (Vec<FrameInfo>, Option<TrapCode>) {
     let info = FRAME_INFO.read().unwrap();
     match &trap {
-        // A user error
-        Trap::User(_err) => (wasm_trace(&info, None, &Backtrace::new_unresolved()), None),
+        // A user error — skip backtrace to avoid _Unwind_Backtrace lock contention
+        Trap::User(_err) => (Vec::new(), None),
         // A trap caused by the VM being Out of Memory
         Trap::OOM { backtrace } => (wasm_trace(&info, None, backtrace), None),
         // A trap caused by an error on the generated machine code for a Wasm function

--- a/lib/vm/src/trap/trap.rs
+++ b/lib/vm/src/trap/trap.rs
@@ -69,10 +69,8 @@ impl Trap {
     }
 
     /// Construct a new Wasm trap with the given trap code.
-    ///
-    /// Internally saves a backtrace when constructed.
     pub fn lib(trap_code: TrapCode) -> Self {
-        let backtrace = Backtrace::new_unresolved();
+        let backtrace = Backtrace::from(vec![]);
         Self::Lib {
             trap_code,
             backtrace,
@@ -80,10 +78,8 @@ impl Trap {
     }
 
     /// Construct a new OOM trap with the given source location and trap code.
-    ///
-    /// Internally saves a backtrace when constructed.
     pub fn oom() -> Self {
-        let backtrace = Backtrace::new_unresolved();
+        let backtrace = Backtrace::from(vec![]);
         Self::OOM { backtrace }
     }
 

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -843,17 +843,15 @@ impl<T> TrapHandlerContextInner<T> {
             })
         });
 
-        // Don't try to generate a backtrace for stack overflows: unwinding
-        // information is often not precise enough to properly describe what is
-        // happenning during a function prologue, which can lead the unwinder to
-        // read invalid memory addresses.
+        // Skip backtrace capture entirely. Backtrace::new_unresolved() calls
+        // _Unwind_Backtrace which invokes _Unwind_Find_FDE for each frame,
+        // taking a process-wide mutex (object_mutex in libgcc or dl_iterate_phdr
+        // in glibc). Under high concurrency this causes severe lock contention
+        // (observed: 67% of CPU in native_queued_spin_lock_slowpath).
         //
-        // See: https://github.com/rust-lang/backtrace-rs/pull/357
-        let backtrace = if signal_trap == Some(TrapCode::StackOverflow) {
-            Backtrace::from(vec![])
-        } else {
-            Backtrace::new_unresolved()
-        };
+        // The WASM-level stack trace (FrameInfo) derived from the backtrace
+        // is lost, but the trap code and error message are preserved.
+        let backtrace = Backtrace::from(vec![]);
 
         // Set up the register state for exception return to force the
         // coroutine to return to its caller with UnwindReason::WasmTrap.


### PR DESCRIPTION
# Description

Eliminate all `Backtrace::new_unresolved()` calls in trap handling paths.

`Backtrace::new_unresolved()` calls `_Unwind_Backtrace`, which invokes
`_Unwind_Find_FDE` for each stack frame. This takes a process-wide mutex (either
`object_mutex` in libgcc or `dl_iterate_phdr`'s internal lock in glibc). Under high
concurrency — hundreds of async tasks executing WASM contracts simultaneously — this
causes severe lock contention. In production we observed 67% of CPU time spent in
`native_queued_spin_lock_slowpath` (the kernel futex spinlock beneath the contended
mutex), pinning workers at 100% CPU utilization.

## Changes

- **`lib/vm/src/trap/traphandlers.rs`**: Always use `Backtrace::from(vec![])` in the
signal-based trap handler instead of conditionally calling `Backtrace::new_unresolved()`
(previously only skipped for stack overflow traps).
- **`lib/vm/src/trap/trap.rs`**: `Trap::lib()` and `Trap::oom()` constructors use empty
backtraces.
- **`lib/compiler/src/engine/trap/stack.rs`**: `Trap::User` variant returns an empty
WASM trace instead of capturing a new backtrace during `Trap` → `RuntimeError`
conversion.

## Trade-off

The WASM-level stack trace (`FrameInfo` frames shown in `RuntimeError` Display) is lost
— error messages will show `RuntimeError: unreachable` without the `at function_name
(module[N]:0xOFFSET)` lines. The trap code and the original panic/error message are
fully preserved.
